### PR TITLE
Prevent double-rendering of content in reviews pages

### DIFF
--- a/symposion_templates/templates/symposion/reviews/base.html
+++ b/symposion_templates/templates/symposion/reviews/base.html
@@ -50,44 +50,37 @@
 
 {% block body_class %}reviews{% endblock %}
 
-{% block body_outer %}
-    <div class="row">
-        <div class="col-md-2">
-            {% block sidebar %}
-            {% for section in review_sections %}
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                    <h3 class="panel-title">{{ section }}</h3>
-                </div>
-                <div class="list-group">
-                  <a class="list-group-item review-list" href="{% url "review_section" section.section.slug %}">
-                      {% trans "All Reviews" %}
-                  </a>
-                  <a class="list-group-item review-list" href="{% url "user_not_reviewed" section.section.slug %}">
-                      {% trans "Unreviewed By You" %}
-                  </a>
-                  {% comment %}
-                  <li>
-                      <a href="{% url "review_section_assignments" section.section.slug %}">
-                          {% trans "Your Assignments" %}
-                      </a>
-                  </li>
-                  {% endcomment %}
-                  <a class="list-group-item voting-status" href="{% url "review_status" section.section.slug %}">
-                      {% trans "Voting Status" %}
-                  </a>
-                  {% if request.user.is_staff %}
-                      <a class="list-group-item review-results" href="{% url "result_notification" section.section.slug 'accepted' %}">Result Notification</a>
-                  {% endif %}
-                </div>
-            {% endfor %}
-            {% endblock %}
-        </div>
-        <div class="col-md-10">
-            {% block body %}
-            {% endblock %}
-        </div>
+{% block sidebar %}
+{% for section in review_sections %}
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">{{ section }}</h3>
     </div>
+    <div class="list-group">
+        <a class="list-group-item review-list" href="{% url "review_section" section.section.slug %}">
+            {% trans "All Reviews" %}
+        </a>
+        <a class="list-group-item review-list" href="{% url "user_not_reviewed" section.section.slug %}">
+            {% trans "Unreviewed By You" %}
+        </a>
+        {% comment %}
+        <li>
+            <a href="{% url "review_section_assignments" section.section.slug %}">
+                {% trans "Your Assignments" %}
+            </a>
+        </li>
+        {% endcomment %}
+        <a class="list-group-item voting-status" href="{% url "review_status" section.section.slug %}">
+            {% trans "Voting Status" %}
+        </a>
+        {% if request.user.is_staff %}
+            <a class="list-group-item review-results" href="{% url "result_notification" section.section.slug 'accepted' %}">Result Notification</a>
+        {% endif %}
+    </div>
+{% endfor %}
+{% endblock %}
+
+{% block body %}
 {% endblock %}
 
 {% block extra_script %}


### PR DESCRIPTION
Removed the unneeded "body-outer" block from the reviews base.html since
it was causing all content in reviews pages to render twice (with the
second time being horribly ugly and sometimes missing data). This was
due to the pyohio-website site_base.html having a "body" block immediately
followed by a "body-outer" block. The reviews templates redefine
"body", which was inserted into the site_base's "body" (as desired), but
having a "body-outer" in reviews that ALSO contained a "body" block
caused the reviews "body" to be placed into the page a second time
(along with the "sidebar" block but let's not even mention that--oh,
drat, too late...).

Anyway. It was confusing to figure out but it's better now.

https://github.com/pyohio/pyohio-website/issues/37 includes screenshots illustrating the problem and the result of this PR.