### PR TITLE
Update proposal details to omit track if no track is set

### DIFF
--- a/symposion_templates/templates/symposion/proposals/_proposal_fields.html
+++ b/symposion_templates/templates/symposion/proposals/_proposal_fields.html
@@ -4,8 +4,10 @@
     <dt>{% trans "Submitted by" %}</dt>
     <dd>{{ proposal.speaker }}</dd>
 
+    {% if proposal.track %}
     <dt>{% trans "Track" %}</dt>
     <dd>{{ proposal.track }}&nbsp;</dd>
+    {% endif %}
 
     <dt>{% trans "Audience Level" %}</dt>
     <dd>{{ proposal.get_audience_level_display }}&nbsp;</dd>

--- a/symposion_templates/templates/symposion/proposals/proposal_detail.html
+++ b/symposion_templates/templates/symposion/proposals/proposal_detail.html
@@ -5,7 +5,13 @@
 {% load bootstrap %}
 
 {% block head_title %}{{ proposal.title }}{% endblock %}
-{% block heading %}#{{ proposal.number }}: {{ proposal.title }} ({{ proposal.speaker }}, Track: {{ proposal.track }}){% endblock %}
+{% block heading %}#{{ proposal.number }}: {{ proposal.title }}
+    {% if proposal.track %}
+        ({{ proposal.speaker }}, Track: {{ proposal.track }})
+    {% else %}
+        ({{ proposal.speaker }})
+    {% endif %}
+{% endblock %}
 
 {% block content %}
   <div class="pull-right">


### PR DESCRIPTION
If a proposal doesn't have a track, don't show "Track: " in the proposal header or the proposal fields.