### PR TITLE
Shorten button text on proposal details to fix layout

### DIFF
--- a/symposion_templates/templates/symposion/proposals/proposal_detail.html
+++ b/symposion_templates/templates/symposion/proposals/proposal_detail.html
@@ -18,10 +18,10 @@
     {% if not proposal.cancelled %}
         {% if request.user == proposal.speaker.user %}
             <a href="{% url "proposal_edit" proposal.pk %}" class="btn btn-default">
-                {% trans "Edit this proposal" %}
+                {% trans "Edit proposal" %}
             </a>
             <a href="{% url "proposal_cancel" proposal.pk %}" class="btn btn-default">
-                {% trans "Cancel this proposal" %}
+                {% trans "Cancel proposal" %}
             </a>
         {% else %}
             <a href="{% url "proposal_leave" proposal.pk %}" class="btn btn-default">


### PR DESCRIPTION
Shortened the "Edit this proposal" and "Cancel this proposal" buttons to
just "Edit proposal" and "Cancel proposal" so that the buttons don't
interfere with the layout of the adjacent tabs on the proposal detail
page.

This fixes https://github.com/pyohio/pyohio-website/issues/41