### PR TITLE
Fix minor a11y issues with the schedule table

### DIFF
--- a/symposion_templates/templates/symposion/schedule/_grid.html
+++ b/symposion_templates/templates/symposion/schedule/_grid.html
@@ -1,7 +1,7 @@
 <table class="calendar table table-bordered">
     <thead>
         <tr>
-            <th class="time">&nbsp;</th>
+            <th class="time" scope="col">&nbsp;</th>
             {% for room in timetable.rooms %}
                 <th scope="col">{{ room.name }}</th>
             {% endfor %}

--- a/symposion_templates/templates/symposion/schedule/_grid.html
+++ b/symposion_templates/templates/symposion/schedule/_grid.html
@@ -3,7 +3,7 @@
         <tr>
             <th class="time">&nbsp;</th>
             {% for room in timetable.rooms %}
-                <th>{{ room.name }}</th>
+                <th scope="col">{{ room.name }}</th>
             {% endfor %}
         </tr>
     </thead>

--- a/symposion_templates/templates/symposion/schedule/schedule_conference.html
+++ b/symposion_templates/templates/symposion/schedule/schedule_conference.html
@@ -23,7 +23,7 @@
     {% for section in sections %}
         {% cache schedule_cache_ttl "schedule-table" section.schedule.section %}
             {% for timetable in section.days %}
-                <h3>{{ section.schedule.section.name }} — {{ timetable.day.date|date:"l, F j, Y" }}</h3>
+                <h2>{{ section.schedule.section.name }} — {{ timetable.day.date|date:"l, F j, Y" }}</h2>
                 {% include "symposion/schedule/_grid.html" %}
             {% endfor %}
         {% endcache %}


### PR DESCRIPTION
* Bumps the headers to h2 to avoid level skips
* Adds `scope="col"` to the table headers, though it doesn't really help for the rows that span multiple columns